### PR TITLE
Fix: PayFirma validates Credit Card even if not selected or active

### DIFF
--- a/class/class.payfirma.php
+++ b/class/class.payfirma.php
@@ -9,6 +9,12 @@ if (!defined('ABSPATH')) exit; // Exit if accessed directly
 add_action('woocommerce_checkout_process', 'payfirma_checkout_field_checks');
 
 function payfirma_checkout_field_checks() {
+    // Only run if Payfirma is the selected payment method
+    if (!isset($_POST['payment_method']) || $_POST['payment_method'] !== 'payfirma_gateway') {
+        return;
+    }
+
+    // Validate the card token
     if (!isset($_COOKIE['tempCardToken']) ||  strlen($_COOKIE['tempCardToken']) != 20){
         unset($_COOKIE['tempCardToken']); 
         wc_add_notice( 'Please check your <strong>Credit Card information</strong>.', $notice_type = 'error' );


### PR DESCRIPTION
As written, this plugin will ask the user to enter their credit card information even if the user has selected a different payment method (Cheque, COD, PayPal etc.) or the PayFirma plugin is inactive in the WooCommerce > Payments. This blocks people from checking out with any other payment method than PayFirma. The only way to stop this is to deactivate the entire plugin (remove PayFirma entirely.)

The `woocommerce_checkout_process` hook you're using here runs every time a user submits an order, and your hook has no validation to ensure that PayFirma is chosen by the user or activated in WooCommerce.

The proposed fix checks that the user actually selected PayFirma as the payment method before validating the credit card information. This also takes care of ensuring PayFirma is active in WooCommerce as well, because if it wasn't active then `$_POST['payment_method']` will never be `payfirma_gateway`.